### PR TITLE
Update readme with some info on other utilities 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 
 # New Features
 
-1: using --aslrdisable when creating boot files will disable aslr in all process.
-2: using --ptracedisable when creating boot files will disable ptrace debugger detection: PT_DENY_ATTACH in the kernel.
+1: using --aslrdisable when creating boot files which will disable aslr in all processes.
+2: using --ptracedisable when creating boot files which will disable ptrace debugger detection(aka PT_DENY_ATTACH in the kernel.)
 
 # Interested in dualbooting or downgrading to lower firmwares? 
 
@@ -25,7 +25,7 @@
 2: [Limefix BlackBird SEP Utility](https://limefix.tech/?product=limefix-sep-utility-testing) (Paid): supports full SEP **untethered downgrades with blobs and tethered downgrades without blobs**  <br>‎ ‎ ‎ ‎ ↳ iOS 9.0-12.5.7 with blobs on A9 devices (10.0-10.3.3 without blobs)
 <br>
 <br>
-3: [LEGACY-IOS-KIT](https://github.com/LukeZGD/Legacy-iOS-Kit) (Free): supports **untethered and tethered downgrades on 32 bit devices**  <br>‎ ‎ ‎ ‎ ↳ for 32-Bit devices and includes 64-Bit support for restoring with futurerestore nightly **with blobs**
+3: [LEGACY-IOS-KIT](https://github.com/LukeZGD/Legacy-iOS-Kit) (Free): supports **untethered and tethered downgrades on 32-Bit devices**  <br>‎ ‎ ‎ ‎ ↳ for 32-Bit devices and includes 64-Bit support for restoring with futurerestore nightly **with blobs**
 
 # How can you dualboot?
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 
 # Interested in dualbooting or downgrading to lower firmwares? 
 
-1: [Semaphorin](https://github.com/hostedbyjustus/Semaphorin-Archive) (Free): supports SEP-less **tethered downgrades and dualboots** <br>‎ ‎ ‎ ‎ ↳ iOS 7.0.6-12.1 (13.x/14.x) on A7-A11 devices
+1: [Semaphorin](https://github.com/LukeZGD/Semaphorin) (Free): supports SEP-less **tethered downgrades and dualboots** <br>‎ ‎ ‎ ‎ ↳ iOS 7.0.6-12.1 (13.x/14.x) on A7-A11 devices
 <br>
 <br>
-2: Limefix SEP Utility (Paid): supports full SEP **untethered and tethered downgrades**  <br>‎ ‎ ‎ ‎ ↳ iOS 9.0-12.5.7 on A9 devices
+2: Limefix BlackBird SEP Utility (Paid): supports full SEP **untethered with blobs and tethered downgrades without blobs**  <br>‎ ‎ ‎ ‎ ↳ iOS 9.0-12.5.7 with blobs on A9 devices (10.0-10.3.3 without blobs)
 <br>
 <br>
 3: [LEGACY-IOS-KIT](https://github.com/LukeZGD/Legacy-iOS-Kit) (Free): supports **untethered and tethered downgrades**  <br>‎ ‎ ‎ ‎ ↳ for 32-Bit devices and includes limited 64-Bit support

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 1: [Semaphorin](https://github.com/LukeZGD/Semaphorin) (Free): supports SEP-less **tethered downgrades and dualboots** <br>‎ ‎ ‎ ‎ ↳ iOS 7.0.6-12.1 (13.x/14.x) on A7-A11 devices
 <br>
 <br>
-2: [Limefix BlackBird SEP Utility](https://limefix.tech/?product=limefix-sep-utility-testing) (Paid): supports full SEP **untethered with blobs and tethered downgrades without blobs**  <br>‎ ‎ ‎ ‎ ↳ iOS 9.0-12.5.7 with blobs on A9 devices (10.0-10.3.3 without blobs)
+2: [Limefix BlackBird SEP Utility](https://limefix.tech/?product=limefix-sep-utility-testing) (Paid): supports full SEP **untethered downgrades with blobs and tethered downgrades without blobs**  <br>‎ ‎ ‎ ‎ ↳ iOS 9.0-12.5.7 with blobs on A9 devices (10.0-10.3.3 without blobs)
 <br>
 <br>
 3: [LEGACY-IOS-KIT](https://github.com/LukeZGD/Legacy-iOS-Kit) (Free): supports **untethered and tethered downgrades**  <br>‎ ‎ ‎ ‎ ↳ for 32-Bit devices and includes limited 64-Bit support

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 # New Features
 
 1: using --aslrdisable when creating boot files which will disable aslr in all processes.
+
 2: using --ptracedisable when creating boot files which will disable ptrace debugger detection (aka PT_DENY_ATTACH in the kernel.)
 
 # Interested in dualbooting or downgrading to lower firmwares? 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 1: [Semaphorin](https://github.com/LukeZGD/Semaphorin) (Free): supports SEP-less **tethered downgrades and dualboots** <br>‎ ‎ ‎ ‎ ↳ iOS 7.0.6-12.1 (13.x/14.x) on A7-A11 devices
 <br>
 <br>
-2: Limefix BlackBird SEP Utility (Paid): supports full SEP **untethered with blobs and tethered downgrades without blobs**  <br>‎ ‎ ‎ ‎ ↳ iOS 9.0-12.5.7 with blobs on A9 devices (10.0-10.3.3 without blobs)
+2: [Limefix BlackBird SEP Utility](https://limefix.tech/?product=limefix-sep-utility-testing) (Paid): supports full SEP **untethered with blobs and tethered downgrades without blobs**  <br>‎ ‎ ‎ ‎ ↳ iOS 9.0-12.5.7 with blobs on A9 devices (10.0-10.3.3 without blobs)
 <br>
 <br>
 3: [LEGACY-IOS-KIT](https://github.com/LukeZGD/Legacy-iOS-Kit) (Free): supports **untethered and tethered downgrades**  <br>‎ ‎ ‎ ‎ ↳ for 32-Bit devices and includes limited 64-Bit support

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 # New Features
 
 1: using --aslrdisable when creating boot files which will disable aslr in all processes.
-2: using --ptracedisable when creating boot files which will disable ptrace debugger detection(aka PT_DENY_ATTACH in the kernel.)
+2: using --ptracedisable when creating boot files which will disable ptrace debugger detection (aka PT_DENY_ATTACH in the kernel.)
 
 # Interested in dualbooting or downgrading to lower firmwares? 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 2: [Limefix BlackBird SEP Utility](https://limefix.tech/?product=limefix-sep-utility-testing) (Paid): supports full SEP **untethered downgrades with blobs and tethered downgrades without blobs**  <br>‎ ‎ ‎ ‎ ↳ iOS 9.0-12.5.7 with blobs on A9 devices (10.0-10.3.3 without blobs)
 <br>
 <br>
-3: [LEGACY-IOS-KIT](https://github.com/LukeZGD/Legacy-iOS-Kit) (Free): supports **untethered and tethered downgrades**  <br>‎ ‎ ‎ ‎ ↳ for 32-Bit devices and includes limited 64-Bit support
+3: [LEGACY-IOS-KIT](https://github.com/LukeZGD/Legacy-iOS-Kit) (Free): supports **untethered and tethered downgrades on 32 bit devices**  <br>‎ ‎ ‎ ‎ ↳ for 32-Bit devices and includes 64-Bit support for restoring with futurerestore nightly **with blobs**
 
 # How can you dualboot?
 


### PR DESCRIPTION
Added more info about limefix such as mentioning that only untethered downgrades can be done with shsh blobs
Added link to [limefix store](https://limefix.tech/?product=limefix-sep-utility-testing) on readme (can revert if not wanted) 
Moved semaphorin link to [LukeZGD's fork](https://github.com/LukeZGD/Semaphorin)
Will also create other pull request if limefix updates at any given time
Added more info on Legacy-Ios-Kit
Wording tweaks
Thanks for reading!